### PR TITLE
Dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+**/.DS_Store
+**/.classpath
+**/.dockerignore
+**/.env
+**/.git
+**/.gitignore
+**/.project
+**/.settings
+**/.toolstarget
+**/.vs
+**/.vscode
+**/*.*proj.user
+**/*.dbmdl
+**/*.jfm
+**/charts
+**/docker-compose*
+**/compose.y*ml
+**/Dockerfile*
+**/node_modules
+**/npm-debug.log
+**/secrets.dev.yaml
+**/values.dev.yaml
+/bin
+/target
+LICENSE
+README.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,21 @@
+name: Docker
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  smoke_test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Server smoke test
+        run: ./scripts/docker-smoke-test.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,71 @@
+# syntax=docker/dockerfile:1
+
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Dockerfile reference guide at
+# https://docs.docker.com/go/dockerfile-reference/
+
+# Want to help us make this template better? Share your feedback here: https://forms.gle/ybq9Krt8jtBL3iCk7
+
+ARG RUST_VERSION=1.94.0
+ARG APP_NAME=redlike
+
+################################################################################
+# Create a stage for building the application.
+
+FROM rust:${RUST_VERSION}-alpine AS build
+ARG APP_NAME
+WORKDIR /app
+
+# Install host build dependencies.
+RUN apk add --no-cache clang lld musl-dev git
+
+# Build the application.
+# Leverage a cache mount to /usr/local/cargo/registry/
+# for downloaded dependencies, a cache mount to /usr/local/cargo/git/db
+# for git repository dependencies, and a cache mount to /app/target/ for
+# compiled dependencies which will speed up subsequent builds.
+# Leverage a bind mount to the src directory to avoid having to copy the
+# source code into the container. Once built, copy the executable to an
+# output directory before the cache mounted /app/target is unmounted.
+RUN --mount=type=bind,source=src,target=src \
+    --mount=type=bind,source=Cargo.toml,target=Cargo.toml \
+    --mount=type=bind,source=Cargo.lock,target=Cargo.lock \
+    --mount=type=cache,target=/app/target/ \
+    --mount=type=cache,target=/usr/local/cargo/git/db \
+    --mount=type=cache,target=/usr/local/cargo/registry/ \
+cargo build --locked --release && \
+cp ./target/release/$APP_NAME /bin/server
+
+################################################################################
+# Create a new stage for running the application that contains the minimal
+# runtime dependencies for the application. This often uses a different base
+# image from the build stage where the necessary files are copied from the build
+# stage.
+#
+# The example below uses the alpine image as the foundation for running the app.
+# By specifying the "3.18" tag, it will use version 3.18 of alpine. If
+# reproducibility is important, consider using a digest
+# (e.g., alpine@sha256:664888ac9cfd28068e062c991ebcff4b4c7307dc8dd4df9e728bedde5c449d91).
+FROM alpine:3.18 AS final
+
+# Create a non-privileged user that the app will run under.
+# See https://docs.docker.com/go/dockerfile-user-best-practices/
+ARG UID=10001
+RUN adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "/nonexistent" \
+    --shell "/sbin/nologin" \
+    --no-create-home \
+    --uid "${UID}" \
+    appuser
+USER appuser
+
+# Copy the executable from the "build" stage.
+COPY --from=build /bin/server /bin/
+
+# Expose the port that the application listens on.
+EXPOSE 6379
+
+# What the container should run when it is started.
+ENTRYPOINT ["/bin/server"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG APP_NAME
 WORKDIR /app
 
 # Install host build dependencies.
-RUN apk add --no-cache clang lld musl-dev git
+RUN apk add --no-cache clang lld musl-dev git 
 
 # Build the application.
 # Leverage a cache mount to /usr/local/cargo/registry/
@@ -51,6 +51,9 @@ FROM alpine:3.18 AS final
 # Create a non-privileged user that the app will run under.
 # See https://docs.docker.com/go/dockerfile-user-best-practices/
 ARG UID=10001
+
+RUN apk add --no-cache su-exec
+
 RUN adduser \
     --disabled-password \
     --gecos "" \
@@ -61,10 +64,7 @@ RUN adduser \
     appuser
 
 # Create directory for optional archive storage
-RUN mkdir /data && chown appuser:appuser /data
-
-USER appuser
-
+RUN mkdir /data 
 
 # Copy the executable from the "build" stage.
 COPY --from=build /bin/server /bin/
@@ -72,5 +72,8 @@ COPY --from=build /bin/server /bin/
 # Expose the port that the application listens on.
 EXPOSE 6379
 
+COPY docker/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 # What the container should run when it is started.
-ENTRYPOINT ["/bin/server"]
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,12 @@ RUN adduser \
     --no-create-home \
     --uid "${UID}" \
     appuser
+
+# Create directory for optional archive storage
+RUN mkdir /data && chown appuser:appuser /data
+
 USER appuser
+
 
 # Copy the executable from the "build" stage.
 COPY --from=build /bin/server /bin/

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -1,0 +1,22 @@
+### Building and running your application
+
+When you're ready, start your application by running:
+`docker compose up --build`.
+
+Your application will be available at http://localhost:6379.
+
+### Deploying your application to the cloud
+
+First, build your image, e.g.: `docker build -t myapp .`.
+If your cloud uses a different CPU architecture than your development
+machine (e.g., you are on a Mac M1 and your cloud provider is amd64),
+you'll want to build the image for that platform, e.g.:
+`docker build --platform=linux/amd64 -t myapp .`.
+
+Then, push it to your registry, e.g. `docker push myregistry.com/myapp`.
+
+Consult Docker's [getting started](https://docs.docker.com/go/get-started-sharing/)
+docs for more detail on building and pushing.
+
+### References
+* [Docker's Rust guide](https://docs.docker.com/language/rust/)

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,12 +1,3 @@
-# Comments are provided throughout this file to help you get started.
-# If you need more help, visit the Docker Compose reference guide at
-# https://docs.docker.com/go/compose-spec-reference/
-
-# Here the instructions define your application as a service called "server".
-# This service is built from the Dockerfile in the current directory.
-# You can add other services your application may depend on here, such as a
-# database or a cache. For examples, see the Awesome Compose repository:
-# https://github.com/docker/awesome-compose
 services:
   server:
     build:

--- a/compose.yaml
+++ b/compose.yaml
@@ -17,37 +17,9 @@ services:
     environment:
       - ADDRESS=0.0.0.0
       - PORT=6379
+      - ARCHIVE_PATH=/data/archive
+    volumes:
+      - data:/data
 
-# The commented out section below is an example of how to define a PostgreSQL
-# database that your application can use. `depends_on` tells Docker Compose to
-# start the database before your application. The `db-data` volume persists the
-# database data between container restarts. The `db-password` secret is used
-# to set the database password. You must create `db/password.txt` and add
-# a password of your choosing to it before running `docker compose up`.
-#     depends_on:
-#       db:
-#         condition: service_healthy
-#   db:
-#     image: postgres
-#     restart: always
-#     user: postgres
-#     secrets:
-#       - db-password
-#     volumes:
-#       - db-data:/var/lib/postgresql/data
-#     environment:
-#       - POSTGRES_DB=example
-#       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
-#     expose:
-#       - 5432
-#     healthcheck:
-#       test: [ "CMD", "pg_isready" ]
-#       interval: 10s
-#       timeout: 5s
-#       retries: 5
-# volumes:
-#   db-data:
-# secrets:
-#   db-password:
-#     file: db/password.txt
-
+volumes:
+  data:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,53 @@
+# Comments are provided throughout this file to help you get started.
+# If you need more help, visit the Docker Compose reference guide at
+# https://docs.docker.com/go/compose-spec-reference/
+
+# Here the instructions define your application as a service called "server".
+# This service is built from the Dockerfile in the current directory.
+# You can add other services your application may depend on here, such as a
+# database or a cache. For examples, see the Awesome Compose repository:
+# https://github.com/docker/awesome-compose
+services:
+  server:
+    build:
+      context: .
+      target: final
+    ports:
+      - 6379:6379
+    environment:
+      - ADDRESS=0.0.0.0
+      - PORT=6379
+
+# The commented out section below is an example of how to define a PostgreSQL
+# database that your application can use. `depends_on` tells Docker Compose to
+# start the database before your application. The `db-data` volume persists the
+# database data between container restarts. The `db-password` secret is used
+# to set the database password. You must create `db/password.txt` and add
+# a password of your choosing to it before running `docker compose up`.
+#     depends_on:
+#       db:
+#         condition: service_healthy
+#   db:
+#     image: postgres
+#     restart: always
+#     user: postgres
+#     secrets:
+#       - db-password
+#     volumes:
+#       - db-data:/var/lib/postgresql/data
+#     environment:
+#       - POSTGRES_DB=example
+#       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
+#     expose:
+#       - 5432
+#     healthcheck:
+#       test: [ "CMD", "pg_isready" ]
+#       interval: 10s
+#       timeout: 5s
+#       retries: 5
+# volumes:
+#   db-data:
+# secrets:
+#   db-password:
+#     file: db/password.txt
+

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+mkdir -p /data 
+echo "created data dir"
+chown appuser:appuser /data 
+echo "dir now belongs to appuser"
+exec su-exec appuser:appuser /bin/server

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Hello world"

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-echo "Hello world"
+docker build -t redlike-smoke-test ../ &&\
+docker compose up --detach &&\
+docker compose down

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -1,4 +1,44 @@
 #!/usr/bin/env bash
-docker build -t redlike-smoke-test ../ &&\
-docker compose up --detach &&\
+set -e
+trap 'docker compose down' EXIT
+echo "Composing"
+docker compose down -v
+docker compose up --detach
+echo "Sending PING"
+response="$(printf '*1\r\n$4\r\nPING\r\n' | nc -N localhost 6379 | tr -d '\r')"
+response="${response%$'\n'}"
+expected="+PONG"
+if [[ "$response" != "$expected" ]]; then
+  printf 'Smoke test failed: expected %q, got %q\n' "$expected" "$response" >&2
+  exit 1
+fi
+echo "SET mykey myvalue"
+response="$(printf '*3\r\n$3\r\nSET\r\n$5\r\nmykey\r\n$7\r\nmyvalue\r\n' | nc -N localhost 6379 | tr -d '\r')"
+response="${response%$'\n'}"
+expected="+OK"
+if [[ "$response" != "$expected" ]]; then
+  printf 'Smoke test failed: expected %q, got %q\n' "$expected" "$response" >&2
+  exit 1
+fi
+echo "GET mykey"
+response="$(printf '*2\r\n$3\r\nGET\r\n$5\r\nmykey\r\n' | nc -N localhost 6379 | tr -d '\r')"
+response="${response%$'\n'}"
+expected=$'$7\nmyvalue'
+if [[ "$response" != "$expected" ]]; then
+  printf 'Smoke test failed: expected %q, got %q\n' "$expected" "$response" >&2
+  exit 1
+fi
+echo "Compose down..."
 docker compose down
+echo "Compose up again to check if archive is restored"
+docker compose up --detach
+echo "GET mykey"
+response="$(printf '*2\r\n$3\r\nGET\r\n$5\r\nmykey\r\n' | nc -N localhost 6379 | tr -d '\r')"
+response="${response%$'\n'}"
+expected=$'$7\nmyvalue'
+if [[ "$response" != "$expected" ]]; then
+  printf 'Smoke test failed: expected %q, got %q\n' "$expected" "$response" >&2
+  exit 1
+fi
+echo "Smoke test complete"
+

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -1,9 +1,33 @@
 #!/usr/bin/env bash
+cleanup() {
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    echo "Smoke test failed, printing container logs" >&2
+    docker compose logs server >&2 || true
+  fi
+  docker compose down -v || true
+  exit "$status"
+}
+
 set -e
-trap 'docker compose down' EXIT
+trap cleanup EXIT
+
+wait_for_server() {
+  for _ in $(seq 1 30); do
+    if printf '*1\r\n$4\r\nPING\r\n' | nc -N localhost 6379 >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "Smoke test failed: server did not become ready in time" >&2
+  exit 1
+}
+
 echo "Composing"
 docker compose down -v
 docker compose up --detach
+wait_for_server
 echo "Sending PING"
 response="$(printf '*1\r\n$4\r\nPING\r\n' | nc -N localhost 6379 | tr -d '\r')"
 response="${response%$'\n'}"
@@ -32,6 +56,7 @@ echo "Compose down..."
 docker compose down
 echo "Compose up again to check if archive is restored"
 docker compose up --detach
+wait_for_server
 echo "GET mykey"
 response="$(printf '*2\r\n$3\r\nGET\r\n$5\r\nmykey\r\n' | nc -N localhost 6379 | tr -d '\r')"
 response="${response%$'\n'}"
@@ -41,4 +66,3 @@ if [[ "$response" != "$expected" ]]; then
   exit 1
 fi
 echo "Smoke test complete"
-


### PR DESCRIPTION
## Summary

This branch adds a complete Docker workflow for running and validating Redlike as a containerized service.

## What’s Included

- a multi-stage Docker build for the Redlike server
- a Compose setup for running the service on port `6379`
- archive persistence backed by a Docker volume
- a Docker smoke test that verifies:
  - container startup
  - RESP `PING`
  - `SET` / `GET`
  - persistence across shutdown and restart
- a dedicated GitHub Actions workflow for Docker smoke testing
- updated Docker documentation

## Why

This branch extends Redlike beyond local `cargo run` usage by making the server runnable and testable in a containerized environment. It also adds automated verification for the Docker path, including the persistence behavior that Rust tests alone do not cover.

## Notes

- the container runs the server as a non-root user after preparing the mounted data directory
- archive data is stored in a named Docker volume mounted at `/data`
- Docker CI is separated from the Rust workflow to keep container checks isolated and easier to diagnose
